### PR TITLE
Configure default level logging for AppInsights

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -168,6 +168,10 @@
                             {
                                 "name": "Configuration__CosmosDbConnections__HelpPages__PartitionKey",
                                 "value": "[variables('CosmosDbCollectionPartitionKey')]"
+                            },
+                            {
+                                "name": "Logging__ApplicationInsights__LogLevel__Default",
+                                "value": "Information"
                             }
                         ]
                     }


### PR DESCRIPTION
Added default level as "Information" for application insights