### PR TITLE
Release v1.1.44.1

### DIFF
--- a/DFC.App.ContentPages.Data/DFC.App.ContentPages.Data.csproj
+++ b/DFC.App.ContentPages.Data/DFC.App.ContentPages.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <ProjectGuid>{640DA7B9-64E2-4DF6-9E0F-66287E485424}</ProjectGuid>
   </PropertyGroup>

--- a/DFC.App.ContentPages.IntegrationTests/DFC.App.ContentPages.IntegrationTests.csproj
+++ b/DFC.App.ContentPages.IntegrationTests/DFC.App.ContentPages.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -15,14 +15,15 @@
 
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.ContentPages.MessageFunctionApp.UnitTests/DFC.App.ContentPages.MessageFunctionApp.UnitTests.csproj
+++ b/DFC.App.ContentPages.MessageFunctionApp.UnitTests/DFC.App.ContentPages.MessageFunctionApp.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -14,13 +14,13 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.2.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7">
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.ContentPages.MessageFunctionApp.UnitTests/Services/MessageProcessorTests.cs
+++ b/DFC.App.ContentPages.MessageFunctionApp.UnitTests/Services/MessageProcessorTests.cs
@@ -104,7 +104,7 @@ namespace DFC.App.ContentPages.MessageFunctionApp.UnitTests.Services
 
             // assert
             A.CallTo(() => mappingService.MapToContentPageModel(message, sequenceNumber)).MustHaveHappenedOnceExactly();
-            Assert.Equal("Invalid message action '-1' received, should be one of 'Published,Deleted,Draft'\r\nParameter name: messageAction", exceptionResult.Message);
+            Assert.Equal("Invalid message action '-1' received, should be one of 'Published,Deleted,Draft' (Parameter 'messageAction')", exceptionResult.Message);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace DFC.App.ContentPages.MessageFunctionApp.UnitTests.Services
             var exceptionResult = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await messageProcessor.ProcessAsync(string.Empty, 1, (MessageContentType)(-1), MessageAction.Published).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Unexpected sitefinity content type '-1'\r\nParameter name: messageContentType", exceptionResult.Message);
+            Assert.Equal("Unexpected sitefinity content type '-1' (Parameter 'messageContentType')", exceptionResult.Message);
         }
     }
 }

--- a/DFC.App.ContentPages.MessageFunctionApp/DFC.App.ContentPages.MessageFunctionApp.csproj
+++ b/DFC.App.ContentPages.MessageFunctionApp/DFC.App.ContentPages.MessageFunctionApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <ProjectGuid>{3B292DA2-CCF4-4B3D-A324-C1C9B181DEE7}</ProjectGuid>
@@ -14,12 +14,12 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="DFC.Functions.DI.Standard" Version="0.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceCreateTests.cs
+++ b/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceCreateTests.cs
@@ -43,7 +43,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.UpsertAsync(null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: contentPageModel", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'contentPageModel')", exceptionResult.Message);
         }
 
         [Fact]

--- a/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceGetAllCategoryTests.cs
+++ b/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceGetAllCategoryTests.cs
@@ -63,7 +63,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.GetAllAsync(null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: category", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'category')", exceptionResult.Message);
         }
     }
 }

--- a/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceGetByAlternativeNameTests.cs
+++ b/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceGetByAlternativeNameTests.cs
@@ -43,7 +43,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.GetByAlternativeNameAsync(category, null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: alternativeName", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'alternativeName')", exceptionResult.Message);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.GetByAlternativeNameAsync(null, alternativeName).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: category", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'category')", exceptionResult.Message);
         }
 
         [Fact]

--- a/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceGetByNameTests.cs
+++ b/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceGetByNameTests.cs
@@ -46,7 +46,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.GetByNameAsync(Category, null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: canonicalName", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'canonicalName')", exceptionResult.Message);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.GetByNameAsync(null, CanonicalName).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: category", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'category')", exceptionResult.Message);
         }
 
         [Fact]

--- a/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceUpdateTests.cs
+++ b/DFC.App.ContentPages.PageService.UnitTests/ContentPageServiceTests/ContentPageServiceUpdateTests.cs
@@ -42,7 +42,7 @@ namespace DFC.App.ContentPages.PageService.UnitTests.ContentPageServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contentPageService.UpsertAsync(null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: contentPageModel", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'contentPageModel')", exceptionResult.Message);
         }
 
         [Fact]

--- a/DFC.App.ContentPages.PageService.UnitTests/DFC.App.ContentPages.PageService.UnitTests.csproj
+++ b/DFC.App.ContentPages.PageService.UnitTests/DFC.App.ContentPages.PageService.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.5.0" />
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.ContentPages.PageService/DFC.App.ContentPages.PageService.csproj
+++ b/DFC.App.ContentPages.PageService/DFC.App.ContentPages.PageService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <ProjectGuid>{1A050760-CDE9-49F6-9F8F-9CB6DD1931E9}</ProjectGuid>
   </PropertyGroup>

--- a/DFC.App.ContentPages.PagesModule.UnitTests/DFC.App.ContentPages.PagesModule.UnitTests.csproj
+++ b/DFC.App.ContentPages.PagesModule.UnitTests/DFC.App.ContentPages.PagesModule.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -13,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.5.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.ContentPages.Repository.CosmosDb/DFC.App.ContentPages.Repository.CosmosDb.csproj
+++ b/DFC.App.ContentPages.Repository.CosmosDb/DFC.App.ContentPages.Repository.CosmosDb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <ProjectGuid>{97725378-373F-455C-AD8C-86805E5C8076}</ProjectGuid>
   </PropertyGroup>
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.ContentPages.UnitTests/DFC.App.ContentPages.UnitTests.csproj
+++ b/DFC.App.ContentPages.UnitTests/DFC.App.ContentPages.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <ProjectGuid>{424399D1-C9AC-4360-9C27-3B0CCFEF1D9E}</ProjectGuid>
   </PropertyGroup>
@@ -11,16 +11,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.ContentPages/Controllers/HealthController.cs
+++ b/DFC.App.ContentPages/Controllers/HealthController.cs
@@ -53,6 +53,7 @@ namespace DFC.App.ContentPages.Controllers
         }
 
         [HttpGet]
+        [Route("/")]
         [Route("health/ping")]
         public IActionResult Ping()
         {

--- a/DFC.App.ContentPages/Controllers/PagesController.cs
+++ b/DFC.App.ContentPages/Controllers/PagesController.cs
@@ -30,7 +30,6 @@ namespace DFC.App.ContentPages.Controllers
         }
 
         [HttpGet]
-        [Route("/")]
         [Route("pages")]
         public async Task<IActionResult> Index()
         {

--- a/DFC.App.ContentPages/DFC.App.ContentPages.csproj
+++ b/DFC.App.ContentPages/DFC.App.ContentPages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <ProjectGuid>{5850940A-42C1-489D-978B-5C016C1BC805}</ProjectGuid>
@@ -17,15 +17,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.96" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DFC.App.ContentPages/Startup.cs
+++ b/DFC.App.ContentPages/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
@@ -30,7 +31,7 @@ namespace DFC.App.ContentPages
             this.configuration = configuration;
         }
 
-        public static void Configure(IApplicationBuilder app, IHostingEnvironment env, IMapper mapper)
+        public static void Configure(IApplicationBuilder app, IWebHostEnvironment env, IMapper mapper)
         {
             if (env.IsDevelopment())
             {
@@ -45,15 +46,14 @@ namespace DFC.App.ContentPages
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCookiePolicy();
-
-            app.UseMvc(routes =>
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
             {
-                // add the default route
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Pages}/{action=Index}");
-            });
+                endpoints.MapRazorPages();
 
+                // add the default route
+                endpoints.MapControllerRoute("default", "{controller=Health}/{action=Ping}");
+            });
             mapper?.ConfigurationProvider.AssertConfigurationIsValid();
         }
 
@@ -83,7 +83,8 @@ namespace DFC.App.ContentPages
                     config.RespectBrowserAcceptHeader = true;
                     config.ReturnHttpNotAcceptable = true;
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+                .AddNewtonsoftJson()
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
         }
     }
 }

--- a/DFC.App.ContentPages/Views/Pages/Body.cshtml
+++ b/DFC.App.ContentPages/Views/Pages/Body.cshtml
@@ -1,5 +1,6 @@
 ﻿@model BodyViewModel
 
+
 @if (Model.Content != null)
 {
     <div class="govuk-width-container">

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -58,6 +58,9 @@
         },
         "cmsSubscriptionSqlFilter": {
             "value": "__cmsSubscriptionSqlFilter__"
+        },
+        "enableAlerts": {
+            "value": __EnableAzureMonitorAlerting__
         }
     }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -72,6 +72,12 @@
             "metadata": {
                 "description": "Filter to apply to subscription (no filter applied if left blank)"
             }
+        },
+        "enableAlerts": {
+            "type": "bool",
+            "metadata": {
+                "description": "Enable or disable alerting"
+            }
         }
     },
     "variables": {
@@ -87,7 +93,8 @@
         "functionAppName": "[concat(variables('ResourcePrefix'), '-fa')]",
         "functionAppInsightsName": "[concat(variables('functionAppName'), '-ai')]",
         "urlContentPages": "[toLower(concat('https://', variables('webAppName'), '.', parameters('appServiceDomain')))]",
-        "cmsSubscriptionName": "content-pages"
+        "cmsSubscriptionName": "content-pages",
+        "ActionGroupName": "[concat('dfc-', replace(tolower(parameters('Environment')), '-draft', ''), '-app-sharedresources-actgrp')]"
     },
     "resources": [
         {
@@ -167,7 +174,7 @@
                         "value": "app"
                     },
                     "deployStagingSlot": {
-                        "value": false
+                        "value": true
                     },
                     "appServiceAppSettings": {
                         "value": [
@@ -261,7 +268,7 @@
                         "value": [
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
-                                "value": "~2"
+                                "value": "~3"
                             },
                             {
                                 "name": "MSDEPLOY_RENAME_LOCKED_FILES",
@@ -392,6 +399,170 @@
                     }
                 }
             }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('webAppInsightsName'), '-metric-exceptions')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('webAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "alertName": {
+                      "value": "[concat(variables('webAppInsightsName'), '-metric-exceptions')]"
+                  },
+                  "alertSeverity": {
+                      "value": 3
+                  },
+                  "metricName": {
+                      "value": "exceptions/count"
+                  },
+                  "operator": {
+                      "value": "GreaterThan"
+                  },
+                  "threshold": {
+                      "value": "0"
+                  },
+                  "aggregation": {
+                      "value": "Count"
+                  },
+                  "windowSize": {
+                      "value": "PT5M"
+                  },
+                  "evaluationFrequency": {
+                      "value": "PT1M"
+                  },
+                  "actionGroupName": {
+                      "value": "[variables('ActionGroupName')]"
+                  },
+                  "actionGroupResourceGroup": {
+                      "value": "[parameters('appSharedResourceGroup')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('webAppInsightsName'))]"
+                  }
+              }
+          }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('webAppInsightsName'), '-failure-anomaly-v2')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('webAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/failure-anomaly-rule.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "alertName": {
+                      "value": "[concat(variables('webAppInsightsName'), '-failure-anomaly-v2')]"
+                  },
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('webAppInsightsName'))]"
+                  },
+                  "actionGroupId": {
+                      "value": "[resourceId(parameters('appSharedResourceGroup'), 'microsoft.insights/actionGroups', variables('ActionGroupName'))]"
+                  }
+              }
+          }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('functionAppInsightsName'), '-metric-exceptions')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('webAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "alertName": {
+                      "value": "[concat(variables('functionAppInsightsName'), '-metric-exceptions')]"
+                  },
+                  "alertSeverity": {
+                      "value": 3
+                  },
+                  "metricName": {
+                      "value": "exceptions/count"
+                  },
+                  "operator": {
+                      "value": "GreaterThan"
+                  },
+                  "threshold": {
+                      "value": "0"
+                  },
+                  "aggregation": {
+                      "value": "Count"
+                  },
+                  "windowSize": {
+                      "value": "PT5M"
+                  },
+                  "evaluationFrequency": {
+                      "value": "PT1M"
+                  },
+                  "actionGroupName": {
+                      "value": "[variables('ActionGroupName')]"
+                  },
+                  "actionGroupResourceGroup": {
+                      "value": "[parameters('appSharedResourceGroup')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('functionAppInsightsName'))]"
+                  }
+              }
+          }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('functionAppInsightsName'), '-failure-anomaly-v2')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('functionAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/failure-anomaly-rule.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "alertName": {
+                      "value": "[concat(variables('functionAppInsightsName'), '-failure-anomaly-v2')]"
+                  },
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('functionAppInsightsName'))]"
+                  },
+                  "actionGroupId": {
+                      "value": "[resourceId(parameters('appSharedResourceGroup'), 'microsoft.insights/actionGroups', variables('ActionGroupName'))]"
+                  }
+              }
+          }
         }
     ],
     "outputs": {

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -40,6 +40,9 @@
         },
         "SharedAppServicePlanResourceGroup": {
             "value": "dfc-dev-compui-shared-rg"
+        },
+        "enableAlerts": {
+            "value": false
         }
     }
 }

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
 - job: BuildDotNetCore
   displayName: Build-DotNetCore
   pool:
-    name: Continuous Integration 02 - SSD - 160ACU
+    name: NCS - CI and CD
     demands:
     - msbuild
     - visualstudio
@@ -36,7 +36,7 @@ jobs:
       SolutionBaseName: $(SolutionBaseName)
       BuildPlatform: $(BuildPlatform)
       BuildConfiguration: $(BuildConfiguration)
-      DotNetCoreVersion: 2.2.402
+      DotNetCoreVersion: 3.1.101
       PublishWebApp: true
       TestSuffix: UnitTests
 
@@ -46,6 +46,6 @@ jobs:
       SolutionBaseName: $(SolutionBaseName).MessageFunctionApp
       BuildPlatform: $(BuildPlatform)
       BuildConfiguration: $(BuildConfiguration)
-      DotNetCoreVersion: 2.2.402
+      DotNetCoreVersion: 3.1.101
       PublishWebApp: true
       TestSuffix: UnitTests

--- a/Resources/PageRegistration/registration.json
+++ b/Resources/PageRegistration/registration.json
@@ -1,81 +1,83 @@
 [
-	{
-		"Path": "help",
-		"TopNavigationOrder": 999,
-		"Layout": 2,
-		"OfflineHtml": "<div class=\"govuk-width-container\"><H2>Help Service Unavailable</H2></div>",
-		"SitemapUrl": "https://__AppServiceName__.__appServiceDomain__/help/sitemap.xml",
-		"RobotsUrl": "https://__AppServiceName__.__appServiceDomain__/Robots.txt",
-		"Regions": [
+  {
+    "Path": "help",
+    "TopNavigationOrder": 999,
+    "Layout": 2,
+    "OfflineHtml": "<div class=\"govuk-width-container\"><H2>Help Service Unavailable</H2></div>",
+    "PhaseBannerHtml": "<div class=\"govuk-phase-banner\"><p class=\"govuk-phase-banner__content\"><strong class=\"govuk-tag govuk-phase-banner__content__tag \">beta</strong> <span class=\"govuk-phase-banner__text\">Complete <a target=\"_blank\" class=\"govuk-link\" href=\"https://surveys.ipsosinteractive.com/mrIWeb/mrIWeb.dll?I.Project=S1039833&amp;id=&amp;cf=ovl \">Ipsos MORI survey</a> to give us your feedback about the service.</span> </p></div>",
+    "SitemapUrl": "https://__AppServiceName__.__appServiceDomain__/help/sitemap.xml",
+    "RobotsUrl": "https://__AppServiceName__.__appServiceDomain__/Robots.txt",
+    "Regions": [
       {
         "PageRegion": 1,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/help/{0}/htmlhead",
-				"IsHealthy" : true
+        "IsHealthy" : true
       },
       {
         "PageRegion": 2,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/help/{0}/breadcrumb",
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "IsHealthy" : true
       },
       {
         "PageRegion": 3,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/help/{0}/bodytop",
         "IsHealthy" : true
       },
       {
         "PageRegion": 4,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/help/{0}/contents",
         "OfflineHtml": "<div class=\"govuk-width-container\"><H3>Help Service Unavailable</H3></div>",
         "IsHealthy" : true
       },
       {
         "PageRegion": 7,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/help/{0}/bodyfooter",
         "IsHealthy" : true
       }
-		]
-	},
+    ]
+  },
   {
     "Path": "alerts",
     "TopNavigationOrder": 999,
     "Layout": 2,
     "OfflineHtml": "<div class=\"govuk-width-container\"><H2>Alert Service Unavailable</H2></div>",
+    "PhaseBannerHtml": "<div class=\"govuk-phase-banner\"><p class=\"govuk-phase-banner__content\"><strong class=\"govuk-tag govuk-phase-banner__content__tag \">beta</strong> <span class=\"govuk-phase-banner__text\">Complete <a target=\"_blank\" class=\"govuk-link\" href=\"https://surveys.ipsosinteractive.com/mrIWeb/mrIWeb.dll?I.Project=S1039833&amp;id=&amp;cf=ovl \">Ipsos MORI survey</a> to give us your feedback about the service.</span> </p></div>",
     "SitemapUrl": null,
     "RobotsUrl": "https://__AppServiceName__.__appServiceDomain__/Robots.txt",
     "Regions": [
       {
         "PageRegion": 1,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/alerts/{0}/htmlhead",
         "IsHealthy" : true
       },
       {
         "PageRegion": 2,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/alerts/{0}/breadcrumb",
         "IsHealthy" : true
       },
       {
         "PageRegion": 3,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/alerts/{0}/bodytop",
         "IsHealthy" : true
       },
       {
         "PageRegion": 4,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/alerts/{0}/contents",
         "OfflineHtml": "<div class=\"govuk-width-container\"><H3>Alert Service Unavailable</H3></div>",
         "IsHealthy" : true
       },
       {
         "PageRegion": 7,
-        "HealthCheckRequired": false,
+        "HealthCheckRequired": true,
         "RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/pages/alerts/{0}/bodyfooter",
         "IsHealthy" : true
       }


### PR DESCRIPTION
### This release contains the following changes
- deployStagingSlot: true (#96)
- Changed agent pool to NCS - CI and CD (#95)
- DFC-11577 Added banner to alert pages as well (#94)
- DFC-11577-updated the phase banner in registrations.json (#93)
- DFC-11577-Added missing banner (#92)
- Added Newtonsoft package (#91)
- DFC-12205-fixed issue with version (#90)
- DFC-12205-Updated nuget packages and also updated version from 3.1.10… (#89)
 - Moving default page to health/ping as it is used by Az keep alive (#88)
- NCSD-3045: Adds alerting for web/function app (#87)
- DFC-12205: YAML build (#86)
- DFC-12205-Updated netcoreapp version from 2.2 to 3.1 (#85)
- Re-enable healthchecks for content pages (#84)